### PR TITLE
Difficulty-adjusted List Points

### DIFF
--- a/src/standard.rs
+++ b/src/standard.rs
@@ -8,8 +8,37 @@ pub struct StandardPointCalculator {
     pub list_size: i32
 }
 
+impl StandardPointCalculator {
+    fn calculate_victor_bonus(&self, victor_max: f64) -> f64 {
+        // Set constants for the calculation.
+        let victor_multiplier = 2.5f64;
+
+        // Calculates an exponential function based off the victor count.
+        let victor_exponent = f64::exp((self.victor_count as f64 * victor_multiplier) / self.list_size as f64);
+
+        // Return the victor bonus.
+        victor_max / (victor_exponent * self.position as f64)
+    }
+}
+
 impl PointCalculator for StandardPointCalculator {
     fn calculate(&self) -> f64 {
-        0.0
+        if self.position > self.list_size {
+            // Return nothing for legacy challenges.
+            return 0.0f64
+        }
+
+        // Set constants for the calculation.
+        let maximum: f64 = 250.0f64;
+        let victor_maximum: f64 = 150.0f64;
+
+        // Calculate a set divisor based off the size of the list.
+        let position_divisor = self.list_size as f64 / f64::ln(maximum / 2.0f64);
+
+        // Calculate the victor bonus.
+        let victor_bonus = self.calculate_victor_bonus(victor_maximum);
+
+        // Return the calculated points.
+        (250.0f64 / (f64::powi((self.position as f64 - 1.0f64) / position_divisor, 2) + 1.0f64)) + victor_bonus
     }
 }

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -9,12 +9,7 @@ pub struct StandardPointCalculator {
 }
 
 impl PointCalculator for StandardPointCalculator {
-    // 250 * EXP(LN(250 / 5) / (1 - list_size) * (demon - 1))
-    // 250f64 * f64::exp(f64::ln(250f64 / 15f64) / (1f64 - 75f64) * (f64::from(self.base.position) - 1f64));
     fn calculate(&self) -> f64 {
-        let top_value: f64 = 250.0;
-        let low_value: f64 = 5.0;
-        
-        250.0f64 * f64::exp(f64::ln(top_value / low_value) / (1.0f64 - self.list_size as f64) * (f64::from(self.position) - 1.0f64))
+        0.0
     }
 }


### PR DESCRIPTION
This Pull Request is made to track my ongoing drafted proposal to streamline list points as a rewarding incentive based on the positional and relative difficulty of a challenge. Currently, this is done by accounting for the fact that average challenge difficulty spans across a standardly distributed curve, and takes a new approach to calculating base points based off this by utilizing a sine-like function rather than an exponential function like the current solution.

Additionally, it adds a exponentially decreasing incentive formally known as a `victor bonus` to incentivize players to traditionally play challenges they wouldn't, and resulting reward them based on how little people have touched upon that challenge. This plays in part with the hypothesis that theoretically; challenges are generally easier than the other challenges placed around them on the basis that more people gravitate towards the accessible challenges, rather than ones that are seen as "obnoxious" which can be regarded as a form of difficulty.

The document detailing certain data surrounding the newer algorithms can be found in [this document](https://docs.google.com/document/d/1-gVfJIjitQeTV_7L00ExsuDkS5OLjvmi3t-prMzIi2g/edit#) that I have drafted here.

| Current Champions & Authors |
| ---------------------------------  |
| Irisu                                           |